### PR TITLE
Changes requested 2022-08-12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,9 @@ jobs:
 
       - name: start time
         id: start
-        run: printf "::set-output name=start_time::$('%(%s)T\n')"
+        run: |
+          printf -v now '%(%s)T'
+          echo "::set-output name=start_time::$now"
       
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -147,13 +149,17 @@ jobs:
       - name: Get job conclusion (success or failure) ########
         id: job_conclusion
         run: |
-          echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
-          echo "::set-output name=build_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
+          echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq '.jobs[0].conclusion')"
+          echo "::set-output name=build_conclusion::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq '.jobs[1].conclusion')"
 
       - id: calculate_duration
         run: |
           printf -v now '%(%s)T'
-          ELPSD=$((now - ${{needs.test.outputs.start_time}}))
+          ELPSD=$(($now - ${{needs.test.outputs.start_time}}))
           echo "::set-output name=elapsed::$ELPSD"
 
       #---Email notifications with elapsed time---

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,10 +146,10 @@ jobs:
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: |
-            Build job for ${{ github.repository }} has completed. \
-            Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }}, \
-            for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }}. \
+          body:
+            Build job for ${{ github.repository }} has completed.
+            Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }},
+            for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }}.
             Workflow execution time ${{ steps.calculate_duration.outputs.elapsed }} sec.
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7}} && docker push $REGISTRY/$IMAGE_NAME:latest
+          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} && docker push $REGISTRY/$IMAGE_NAME:latest
 
       #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
       #- name: Log in to the Container registry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,11 +114,11 @@ jobs:
         run: |
           for i in {0..1}
           do
-          combined=job_${i}_conclusion
-          echo $combined
-          echo ${combined}
-          echo ${!combined}
-          echo "::set-output name=${combined}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          jobi=job_${i}_conclusion
+          echo "1--$jobi"
+          echo "2--${jobi}""
+          echo "3--${!jobi}""
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[$i].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body:
+          body: |
             Build job for ${{ github.repository }} has completed.
             Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }},
             for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }}.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           do
           jobi=job_${i}_conclusion
           temp=$i
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg ii "$temp" '.jobs[$ii].conclusion')"
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg ii "$temp" '.jobs[$ii|tonumber].conclusion')"
           done
 
       - name: calculate duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           do
           jobi=job_${i}_conclusion
           temp=$i
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg ii "$temp" '.jobs[$ii|tonumber].conclusion')"
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --argjson ii "$temp" '.jobs[$ii].conclusion')"
           done
 
       - name: calculate duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,15 +167,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0      
-          
+
       - name: get email
         id: email
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            git checkout remotes/origin/${{ github.head_ref }}
-            echo "::set-output name=email_address::$(git log -n 1 --pretty=format:%ae)"
+            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/haishulud/angular-react-starter/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
           else
-            echo "::set-output name=email_address::$(${{ github.event.pusher.email }})"
+            echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
 
       - name: Get job conclusion (success or failure)
@@ -200,7 +199,7 @@ jobs:
           # Subject of mail message
           subject: Github Actions job result
           # Recipients mail addresses (separated with comma)
-          to: ${{steps.email.outputs.email_address}} #${{ github.event.pusher.email }}
+          to: ${{ steps.email.outputs.user_email }} #${{ github.event.pusher.email }}
           # Full name of mail sender (might be with an email address specified in <>)
           from: Github CI v2
           # Whether this connection use TLS (default is true if server_port is 465)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,10 +164,6 @@ jobs:
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
       
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0      
-
       - name: get email for Committer on PR or pusher on PUSH
         id: email
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,10 @@ jobs:
       - name: Log in to the Container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
-
+      - name: get PR sha1
+        if: github.event_name == 'pull_request'
+        run: PR_SHA7=${{github.event.pull_request.head.sha}}
+      
       - name: build Docker image on push event
         if: github.event_name == 'push'
         run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
@@ -96,7 +99,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker build -t $REGISTRY/$IMAGE_NAME:${{github.event.pull_request.head.sha}} -t $REGISTRY/$IMAGE_NAME:latest .
+          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7}} -t $REGISTRY/$IMAGE_NAME:latest .
 
       - name: push Docker image on push event
         if: github.event_name == 'push'
@@ -104,7 +107,9 @@ jobs:
 
       - name: push Docker image on PR event
         if: github.event_name == 'pull_request'
-        run: docker push $REGISTRY/$IMAGE_NAME:${github.event.pull_request.head.sha} && docker push $REGISTRY/$IMAGE_NAME:latest
+        run: |
+          PR_SHA7=${{github.event.pull_request.head.sha}}
+          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7}} && docker push $REGISTRY/$IMAGE_NAME:latest
 
       #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
       #- name: Log in to the Container registry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,24 +2,26 @@ name: myCI
 
 on:
   #workflow_dispatch: #manual start from Github UI or API
-  #push:
-    #branches: [master, dev]
-  pull_request:
-    branches: [master, dev]
+  push:
+    branches: master
+  #pull_request:
+    #branches: master
 
 jobs:
-  test_job:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
+  main_job:
+    runs-on: ubuntu-latest
+    permissions:      
+      contents: read  #permissions for publishing Docker images to Github Packages
+      packages: write #permissions for publishing Docker images to Github Packages
+          
     defaults:
       run:
-        working-directory: angular
+        working-directory: angular 
 
     strategy:
       matrix:
         node-version: [16.x]
        #node-version: [16.x, 14.x] #used this line instead of the one above to emulate errors in the test phase AND to test matrix syntax
-    
     steps:
       - uses: actions/checkout@v3
       
@@ -31,10 +33,18 @@ jobs:
       - name: Install dependencies
         #run: npm install
         run: npm ci  		#"ci" is (theoretically?) faster than "install"
+      
+      - name: Buld phase
+        run: npm run build
+      
+      - name: print working dir
+        run: |
+          echo $PWD
+      - run: "ls $PWD"
+      - run: "ls /home/runner/work/angular-react-starter/angular-react-starter/angular/dist/angular-starter"
+      - run: "ls ${{ github.workspace }}"
+      - run: "echo $HOME"
 
-      - name: Linting
-        run: npm run lint
-     
       - name: Test phase
         id: test_phase
         run: npm run test -- --watch=false --browsers=ChromeHeadless
@@ -43,6 +53,31 @@ jobs:
         if: ${{ failure() && steps.test_phase.conclusion == 'failure' }}
         run: exit 1
 
+      - name: Linting
+        run: npm run lint #not in the task, but still running it... just because I can
+      
+      #---Build Docker image, Login & Publish to Docker Packages---
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/${{ github.repository }}
+            
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./angular
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
       #- name: Job's running time !!!!!this approach DOESN'T WORK!!!! because .run_duration_ms parameter is awailable only after this workflow completion and accessible only from other actions, which isn't possible according to this test task conditions (I can't create additional yaml files)
       #  id: execution_time
       #  run: |
@@ -51,133 +86,37 @@ jobs:
       #      -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
       #      https://api.github.com/repos/${{ github.actor }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/timing
 
-
-  build_job:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    needs: test_job
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-
-    permissions:      
-      contents: read  #permissions for publishing Docker images to Github Packages
-      packages: write #permissions for publishing Docker images to Github Packages
-    
-    defaults:
-      run:
-        working-directory: angular
-    
-    steps:
-      - uses: actions/checkout@v3
       
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Buld phase
-        run: npm run build
-
-      #---Build Docker image, Login & Publish to Docker Packages---
-      - name: Log in to the Container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
-
-      - name: build Docker image on push event
-        if: github.event_name == 'push'
-        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
-
-      - name: build Docker image on PR event
-        if: github.event_name == 'pull_request'
-        run: |
-          PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} -t $REGISTRY/$IMAGE_NAME:latest .
-
-      - name: push Docker image on push event
-        if: github.event_name == 'push'
-        run: docker push $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} && docker push $REGISTRY/$IMAGE_NAME:latest
-
-      - name: push Docker image on PR event
-        if: github.event_name == 'pull_request'
-        run: |
-          PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} && docker push $REGISTRY/$IMAGE_NAME:latest
-
-      #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
-      #- name: Log in to the Container registry
-      #  uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-      #  with:
-      #    registry: $REGISTRY
-      #    username: ${{ github.actor }} #${{ github.repository_owner }}
-      #    password: ${{ secrets.GITHUB_TOKEN }}
-      
-      #- name: Extract metadata (tags, labels) for Docker
-      #  id: meta
-      #  uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-      #  with:
-      #    images: $REGISTRY/$IMAGE_NAME
-            
-      #- name: Build and push Docker image
-      #  uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-      #  with:
-      #    context: ./angular
-      #    push: true
-      #    tags: ${{ steps.meta.outputs.tags }}
-      #    labels: ${{ steps.meta.outputs.labels }}
-  
   stats_job:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    if: ${{ always() }}
-    needs: [build_job, test_job]
+    runs-on: ubuntu-latest
+    needs: main_job
     steps:
-      - name:  Extract TEST and BUILD job starting & ending time
+      - name:  Extract job starting & ending time
         id: execution_timestamps
         run: |
-          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
-          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].started_at')" && echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].completed_at')"
-
+          echo "::set-output name=starttime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
+      
       - name: calculate time
         id: calculate_time
         run: |
-          started_at_test=${{steps.execution_timestamps.outputs.starttime_test}}
-          completed_at_test=${{steps.execution_timestamps.outputs.endtime_test}}
-          started_at_build=${{steps.execution_timestamps.outputs.starttime_build}}
-          completed_at_build=${{steps.execution_timestamps.outputs.endtime_build}}
+          started_at=${{steps.execution_timestamps.outputs.starttime}}
+          completed_at=${{steps.execution_timestamps.outputs.endtime}}
 
-          START_TIME_TEST=$(date -d "$started_at_test" +%s)
-          END_TIME_TEST=$(date -d "$completed_at_test" +%s)
-          START_TIME_BUILD=$(date -d "$started_at_build" +%s)
-          END_TIME_BUILD=$(date -d "$completed_at_build" +%s)
+          START_TIME=$(date -d "$started_at" +%s)
+          END_TIME=$(date -d "$completed_at" +%s)
 
-          ELAPSE_TEST=$(( $END_TIME_TEST - $START_TIME_TEST ))
-          ELAPSE_BUILD=$(( $END_TIME_BUILD - $START_TIME_BUILD ))
-          ELAPSE=$(( $ELAPSE_TEST + $ELAPSE_BUILD ))
+          ELAPSE=$(( $END_TIME - $START_TIME ))
           echo $ELAPSE
           echo "$(($ELAPSE/60/60))h $(($ELAPSE/60%60))m $(($ELAPSE%60))s"
           echo "::set-output name=elpsd::$ELAPSE"
           echo "::set-output name=el_hours::$(($ELAPSE/60/60))"
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
-      
-      - name: get email for Committer on PR or pusher on PUSH
-        id: email
-        run: |
-          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
-          else
-            echo "::set-output name=user_email::${{ github.event.pusher.email }}"
-          fi
 
       - name: Get job conclusion (success or failure)
         id: job_conclusion
         run: |
-          echo "::set-output name=test_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
-          echo "::set-output name=build_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
+          echo "::set-output name=main_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
 
       #---Email notifications v2 with elapsed time---
       - name: Send email notifications for this job v2
@@ -185,22 +124,22 @@ jobs:
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:
           # SMTP server address
-          server_address: ${{ secrets.MAIL_SERVER }}
+          server_address: ${{secrets.MAIL_SERVER}}
           # SMTP server port
           server_port: 465 #587
           # Authenticate as this user to SMTP server
-          username: ${{ secrets.MAIL_USERNAME }}
+          username: ${{secrets.MAIL_USERNAME}}
           # Authenticate with this password to SMTP server
-          password: ${{ secrets.MAIL_PASSWORD }}
+          password: ${{secrets.MAIL_PASSWORD}}
           # Subject of mail message
           subject: Github Actions job result
           # Recipients mail addresses (separated with comma)
-          to: ${{ steps.email.outputs.user_email }} #${{ github.event.pusher.email }}
+          to: ${{github.event.pusher.email}}
           # Full name of mail sender (might be with an email address specified in <>)
           from: Github CI v2
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_job_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_job_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
+          body: Build job for ${{github.repository}} has completed. Result status ${{steps.job_conclusion.outputs.main_job_conclusion}}. Time ${{steps.calculate_time.outputs.el_hours}}h ${{steps.calculate_time.outputs.el_minutes}}m ${{steps.calculate_time.outputs.el_seconds}}s (${{steps.calculate_time.outputs.elpsd}} sec)
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,11 @@ jobs:
         run: |
           for i in {0..1}
           do
-          echo "::set-output name=job_${{i}}_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          combined=job_${i}_conclusion
+          echo $combined
+          echo ${combined}
+          echo ${!combined}
+          echo "::set-output name=${combined}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,11 +168,11 @@ jobs:
         with:
           fetch-depth: 0      
 
-      - name: get email
+      - name: get email for Committer on PR or pusher on PUSH
         id: email
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/haishulud/angular-react-starter/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
+            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
           else
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,21 @@ jobs:
       run:
         working-directory: angular
 
+    outputs:
+      start_time: ${{ steps.start.outputs.start_time}}
+
     strategy:
       matrix:
         node-version: [16.x]
-       #node-version: [16.x, 14.x] #used this line instead of the one above to emulate errors in the test phase AND to test matrix syntax
-    
+
     steps:
+      - name: start time
+        id: start
+        run: |
+          #printf -v now '%(%s)T\n'
+          #echo "::set-output name=start_time::$(%(%s)T\n)"
+          printf "::set-output name=start_time::$(%(%s)T\n)"
+
       - uses: actions/checkout@v3
       
       - name: use node.js ${{ matrix.node-version }}
@@ -35,11 +44,11 @@ jobs:
         run: npm run lint
      
       - name: run
-        id: test_phase
+        id: run_test
         run: npm run test -- --watch=false --browsers=ChromeHeadless
 
       - name: check #Check if tests were successful and exit on failure
-        if: ${{ failure() && steps.test_phase.conclusion == 'failure' }}
+        if: ${{ failure() && steps.run_test.conclusion == 'failure' }}
         run: exit 1
 
     
@@ -78,11 +87,10 @@ jobs:
       - name: login #log in to the container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
-      - name: build Docker image on push event ###########
-        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA: -7:0} -t $REGISTRY/$IMAGE_NAME:latest .
+      - name: build image
+        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
 
-      - name: push Docker image on push event ########
-        if: github.event_name == 'push'
+      - name: push image
         run: docker push $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} && docker push $REGISTRY/$IMAGE_NAME:latest
 
   
@@ -95,11 +103,20 @@ jobs:
       - name:  Extract TEST and BUILD job starting & ending time #####
         id: execution_timestamps
         run: |
-          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
-          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].started_at')" && echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].completed_at')"
+          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq '.jobs[0].started_at')"
+          echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq '.jobs[0].completed_at')"
+          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq '.jobs[1].started_at')"
+          echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq '.jobs[1].completed_at')"
 
-      - name: calculate time
-        id: calculate_time
+      - id: calculate_time
         run: |
           started_at_test=${{steps.execution_timestamps.outputs.starttime_test}}
           completed_at_test=${{steps.execution_timestamps.outputs.endtime_test}}
@@ -121,11 +138,11 @@ jobs:
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
       
-      - name: get email for Committer on PR or pusher on PUSH ########
+      - name: get email for Committer on PR or pusher on PUSH ######## #--pretty=format:%ae HEAD
         id: email
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
+            echo "::set-output name=user_email::$(git log -1 --pretty=format:%ae)" 
           else
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
@@ -136,9 +153,16 @@ jobs:
           echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
           echo "::set-output name=build_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
 
+      - id: calculate_duration
+        run: |
+          #echo "::set-output name=elapsed::$((now - ${{needs.test.outputs.start_time}}))"
+          printf -v now '%(%s)T'
+          ELPSD=$((now - ${{needs.test.outputs.start_time}}))
+          echo "::set-output name=elapsed::$ELPSD"
+
       #---Email notifications with elapsed time---
       - name: Send email notifications for this job
-        if: ${{ always() }} #run this step even if previous steps failed
+        if: ${{ always() }} #run this step even if previous steps have failed
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:
           # SMTP server address
@@ -158,6 +182,6 @@ jobs:
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
+          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec) (new time ${{ steps.calculate_duration.outputs.elapsed }} sec)
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,8 @@ jobs:
           for i in {0..1}
           do
           jobi=job_${i}_conclusion
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg i "$i" '.jobs[$i].conclusion')"
+          temp=$i
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg i "$temp" '.jobs[$i].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: buld
         run: npm run build
 
-      #---Build Docker image, Login & Publish to Docker Packages---
+      #---Build Docker image, Login & Publish to remote registry---
       - name: login #log in to the container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
@@ -99,45 +99,7 @@ jobs:
     if: ${{ always() }}
     needs: [build, test]
     steps:
-      - name:  Extract TEST and BUILD job starting & ending time #####
-        id: execution_timestamps
-        run: |
-          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[0].started_at')"
-          echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[0].completed_at')"
-          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[1].started_at')"
-          echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[1].completed_at')"
-
-      - id: calculate_time
-        run: |
-          started_at_test=${{steps.execution_timestamps.outputs.starttime_test}}
-          completed_at_test=${{steps.execution_timestamps.outputs.endtime_test}}
-          started_at_build=${{steps.execution_timestamps.outputs.starttime_build}}
-          completed_at_build=${{steps.execution_timestamps.outputs.endtime_build}}
-
-          START_TIME_TEST=$(date -d "$started_at_test" +%s)
-          END_TIME_TEST=$(date -d "$completed_at_test" +%s)
-          START_TIME_BUILD=$(date -d "$started_at_build" +%s)
-          END_TIME_BUILD=$(date -d "$completed_at_build" +%s)
-
-          ELAPSE_TEST=$(( $END_TIME_TEST - $START_TIME_TEST ))
-          ELAPSE_BUILD=$(( $END_TIME_BUILD - $START_TIME_BUILD ))
-          ELAPSE=$(( $ELAPSE_TEST + $ELAPSE_BUILD ))
-          echo $ELAPSE
-          echo "$(($ELAPSE/60/60))h $(($ELAPSE/60%60))m $(($ELAPSE%60))s"
-          echo "::set-output name=elpsd::$ELAPSE"
-          echo "::set-output name=el_hours::$(($ELAPSE/60/60))"
-          echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
-          echo "::set-output name=el_seconds::$(($ELAPSE%60))"
-      
-      - name: get email for Committer on PR or pusher on PUSH ######## #--pretty=format:%ae HEAD
+      - name: get email
         id: email
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
@@ -146,7 +108,7 @@ jobs:
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
 
-      - name: Get job conclusion (success or failure) ########
+      - name: get job conclusion
         id: job_conclusion
         run: |
           echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" \
@@ -184,6 +146,10 @@ jobs:
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec) (new time ${{ steps.calculate_duration.outputs.elapsed }} sec)
+          body: |
+            Build job for ${{ github.repository }} has completed. \
+            Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }}, \
+            for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }}. \
+            Workflow execution time ${{ steps.calculate_duration.outputs.elapsed }} sec.
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ name: myCI
 on:
   #workflow_dispatch: #manual start from Github UI or API
   push:
-    branches: dev
+    branches: master
   pull_request:
-    branches: dev
+    branches: master
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7}} -t $REGISTRY/$IMAGE_NAME:latest .
+          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} -t $REGISTRY/$IMAGE_NAME:latest .
 
       - name: push Docker image on push event
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ name: myCI
 on:
   #workflow_dispatch: #manual start from Github UI or API
   push:
-    branches: dev
+    branches: master
   pull_request:
-    branches: dev
+    branches: master
 
 jobs:
   test:
@@ -108,7 +108,7 @@ jobs:
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
 
-      - name: get job conclusion
+      - name: get job result
         id: job_conclusion
         run: |
           echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" \
@@ -125,7 +125,7 @@ jobs:
           echo "::set-output name=elapsed::$ELPSD"
 
       #---Email notifications with elapsed time---
-      - name: Send email notifications for this job
+      - name: send email
         if: ${{ always() }} #run this step even if previous steps have failed
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,11 @@ jobs:
         node-version: [16.x]
 
     steps:
+      - uses: actions/checkout@v3
+      
       - name: start time
         id: start
         run: printf "::set-output name=start_time::$(%(%s)T\n)"
-
-      - uses: actions/checkout@v3
       
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,11 @@ jobs:
           echo "::set-output name=el_hours::$(($ELAPSE/60/60))"
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
-
+      
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0      
+          
       - name: get email
         id: email
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,8 @@ name: myCI
 
 on:
   #workflow_dispatch: #manual start from Github UI or API
-  #push:
-    #branches: [master, dev]
+  push:
+    branches: [master, dev]
   pull_request:
     branches: [master, dev]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,26 +2,24 @@ name: myCI
 
 on:
   #workflow_dispatch: #manual start from Github UI or API
-  push:
-    branches: master
-  #pull_request:
-    #branches: master
+  #push:
+    #branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
 
 jobs:
-  main_job:
-    runs-on: ubuntu-latest
-    permissions:      
-      contents: read  #permissions for publishing Docker images to Github Packages
-      packages: write #permissions for publishing Docker images to Github Packages
-          
+  test_job:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
     defaults:
       run:
-        working-directory: angular 
+        working-directory: angular
 
     strategy:
       matrix:
         node-version: [16.x]
        #node-version: [16.x, 14.x] #used this line instead of the one above to emulate errors in the test phase AND to test matrix syntax
+    
     steps:
       - uses: actions/checkout@v3
       
@@ -33,18 +31,10 @@ jobs:
       - name: Install dependencies
         #run: npm install
         run: npm ci  		#"ci" is (theoretically?) faster than "install"
-      
-      - name: Buld phase
-        run: npm run build
-      
-      - name: print working dir
-        run: |
-          echo $PWD
-      - run: "ls $PWD"
-      - run: "ls /home/runner/work/angular-react-starter/angular-react-starter/angular/dist/angular-starter"
-      - run: "ls ${{ github.workspace }}"
-      - run: "echo $HOME"
 
+      - name: Linting
+        run: npm run lint
+     
       - name: Test phase
         id: test_phase
         run: npm run test -- --watch=false --browsers=ChromeHeadless
@@ -53,31 +43,6 @@ jobs:
         if: ${{ failure() && steps.test_phase.conclusion == 'failure' }}
         run: exit 1
 
-      - name: Linting
-        run: npm run lint #not in the task, but still running it... just because I can
-      
-      #---Build Docker image, Login & Publish to Docker Packages---
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ghcr.io/${{ github.repository }}
-            
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: ./angular
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      
       #- name: Job's running time !!!!!this approach DOESN'T WORK!!!! because .run_duration_ms parameter is awailable only after this workflow completion and accessible only from other actions, which isn't possible according to this test task conditions (I can't create additional yaml files)
       #  id: execution_time
       #  run: |
@@ -86,37 +51,133 @@ jobs:
       #      -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
       #      https://api.github.com/repos/${{ github.actor }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/timing
 
-      
-  stats_job:
-    runs-on: ubuntu-latest
-    needs: main_job
+
+  build_job:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    needs: test_job
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    permissions:      
+      contents: read  #permissions for publishing Docker images to Github Packages
+      packages: write #permissions for publishing Docker images to Github Packages
+    
+    defaults:
+      run:
+        working-directory: angular
+    
     steps:
-      - name:  Extract job starting & ending time
+      - uses: actions/checkout@v3
+      
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Buld phase
+        run: npm run build
+
+      #---Build Docker image, Login & Publish to Docker Packages---
+      - name: Log in to the Container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
+
+      - name: build Docker image on push event
+        if: github.event_name == 'push'
+        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
+
+      - name: build Docker image on PR event
+        if: github.event_name == 'pull_request'
+        run: |
+          PR_SHA7=${{github.event.pull_request.head.sha}}
+          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} -t $REGISTRY/$IMAGE_NAME:latest .
+
+      - name: push Docker image on push event
+        if: github.event_name == 'push'
+        run: docker push $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} && docker push $REGISTRY/$IMAGE_NAME:latest
+
+      - name: push Docker image on PR event
+        if: github.event_name == 'pull_request'
+        run: |
+          PR_SHA7=${{github.event.pull_request.head.sha}}
+          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} && docker push $REGISTRY/$IMAGE_NAME:latest
+
+      #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
+      #- name: Log in to the Container registry
+      #  uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      #  with:
+      #    registry: $REGISTRY
+      #    username: ${{ github.actor }} #${{ github.repository_owner }}
+      #    password: ${{ secrets.GITHUB_TOKEN }}
+      
+      #- name: Extract metadata (tags, labels) for Docker
+      #  id: meta
+      #  uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      #  with:
+      #    images: $REGISTRY/$IMAGE_NAME
+            
+      #- name: Build and push Docker image
+      #  uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      #  with:
+      #    context: ./angular
+      #    push: true
+      #    tags: ${{ steps.meta.outputs.tags }}
+      #    labels: ${{ steps.meta.outputs.labels }}
+  
+  stats_job:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    needs: [build_job, test_job]
+    steps:
+      - name:  Extract TEST and BUILD job starting & ending time
         id: execution_timestamps
         run: |
-          echo "::set-output name=starttime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
-      
+          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
+          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].started_at')" && echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].completed_at')"
+
       - name: calculate time
         id: calculate_time
         run: |
-          started_at=${{steps.execution_timestamps.outputs.starttime}}
-          completed_at=${{steps.execution_timestamps.outputs.endtime}}
+          started_at_test=${{steps.execution_timestamps.outputs.starttime_test}}
+          completed_at_test=${{steps.execution_timestamps.outputs.endtime_test}}
+          started_at_build=${{steps.execution_timestamps.outputs.starttime_build}}
+          completed_at_build=${{steps.execution_timestamps.outputs.endtime_build}}
 
-          START_TIME=$(date -d "$started_at" +%s)
-          END_TIME=$(date -d "$completed_at" +%s)
+          START_TIME_TEST=$(date -d "$started_at_test" +%s)
+          END_TIME_TEST=$(date -d "$completed_at_test" +%s)
+          START_TIME_BUILD=$(date -d "$started_at_build" +%s)
+          END_TIME_BUILD=$(date -d "$completed_at_build" +%s)
 
-          ELAPSE=$(( $END_TIME - $START_TIME ))
+          ELAPSE_TEST=$(( $END_TIME_TEST - $START_TIME_TEST ))
+          ELAPSE_BUILD=$(( $END_TIME_BUILD - $START_TIME_BUILD ))
+          ELAPSE=$(( $ELAPSE_TEST + $ELAPSE_BUILD ))
           echo $ELAPSE
           echo "$(($ELAPSE/60/60))h $(($ELAPSE/60%60))m $(($ELAPSE%60))s"
           echo "::set-output name=elpsd::$ELAPSE"
           echo "::set-output name=el_hours::$(($ELAPSE/60/60))"
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
+      
+      - name: get email for Committer on PR or pusher on PUSH
+        id: email
+        run: |
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
+          else
+            echo "::set-output name=user_email::${{ github.event.pusher.email }}"
+          fi
 
       - name: Get job conclusion (success or failure)
         id: job_conclusion
         run: |
-          echo "::set-output name=main_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          echo "::set-output name=test_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          echo "::set-output name=build_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
 
       #---Email notifications v2 with elapsed time---
       - name: Send email notifications for this job v2
@@ -124,22 +185,22 @@ jobs:
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:
           # SMTP server address
-          server_address: ${{secrets.MAIL_SERVER}}
+          server_address: ${{ secrets.MAIL_SERVER }}
           # SMTP server port
           server_port: 465 #587
           # Authenticate as this user to SMTP server
-          username: ${{secrets.MAIL_USERNAME}}
+          username: ${{ secrets.MAIL_USERNAME }}
           # Authenticate with this password to SMTP server
-          password: ${{secrets.MAIL_PASSWORD}}
+          password: ${{ secrets.MAIL_PASSWORD }}
           # Subject of mail message
           subject: Github Actions job result
           # Recipients mail addresses (separated with comma)
-          to: ${{github.event.pusher.email}}
+          to: ${{ steps.email.outputs.user_email }} #${{ github.event.pusher.email }}
           # Full name of mail sender (might be with an email address specified in <>)
           from: Github CI v2
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{github.repository}} has completed. Result status ${{steps.job_conclusion.outputs.main_job_conclusion}}. Time ${{steps.calculate_time.outputs.el_hours}}h ${{steps.calculate_time.outputs.el_minutes}}m ${{steps.calculate_time.outputs.el_seconds}}s (${{steps.calculate_time.outputs.elpsd}} sec)
+          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_job_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_job_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,10 +99,6 @@ jobs:
     if: ${{ always() }}
     needs: [build, test]
     
-    strategy:
-      matrix:
-        job-index: [0, 1]
-
     steps:
       - name: get email
         id: email
@@ -116,8 +112,7 @@ jobs:
       - name: get job result
         id: job_conclusion
         run: |
-          for i in 0 1
-          do
+          for i in 0 1; do
             echo "::set-output name=job_$i_conclusion::$(curl -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
             | jq '.jobs[$i].conclusion')"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,15 +109,12 @@ jobs:
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
 
-      - name: get job result
+      - name: get job result #echo ${{ job_$i_conclusion }} echo ${{ job_0_conclusion }} echo "i: $i"
         id: job_conclusion
         run: |
           for i in {0..1}
           do
-          echo "i: $i"
-          echo "::set-output name=job_$i_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[$i].conclusion')"
-          echo ${{ job_$i_conclusion }}
-          echo ${{ job_0_conclusion }}
+          echo "::set-output name=job_${i}_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[${i}].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
         run: |
           for i in {0..1}
           do
-          echo "::set-output name=job_${i}_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[${i}].conclusion')"
+          echo "::set-output name=job_${{i}}_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,10 @@ jobs:
     needs: [build, test]
     
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: get email
         id: email
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: start time
         id: start
-        run: printf "::set-output name=start_time::$(%(%s)T\n)"
+        run: printf "::set-output name=start_time::$('%(%s)T\n')"
       
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,7 @@ jobs:
     steps:
       - name: start time
         id: start
-        run: |
-          #printf -v now '%(%s)T\n'
-          #echo "::set-output name=start_time::$(%(%s)T\n)"
-          printf "::set-output name=start_time::$(%(%s)T\n)"
+        run: printf "::set-output name=start_time::$(%(%s)T\n)"
 
       - uses: actions/checkout@v3
       
@@ -155,7 +152,6 @@ jobs:
 
       - id: calculate_duration
         run: |
-          #echo "::set-output name=elapsed::$((now - ${{needs.test.outputs.start_time}}))"
           printf -v now '%(%s)T'
           ELPSD=$((now - ${{needs.test.outputs.start_time}}))
           echo "::set-output name=elapsed::$ELPSD"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,9 +116,9 @@ jobs:
           do
           jobi=job_${i}_conclusion
           echo "1--$jobi"
-          echo "2--${jobi}""
-          echo "3--${!jobi}""
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[$i].conclusion')"
+          echo "2--${jobi}"
+          echo "3--${!jobi}"
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[${i}].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,25 +3,23 @@ name: myCI
 on:
   #workflow_dispatch: #manual start from Github UI or API
   push:
-    branches: master
-  #pull_request:
-    #branches: master
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
 
 jobs:
-  main_job:
-    runs-on: ubuntu-latest
-    permissions:      
-      contents: read  #permissions for publishing Docker images to Github Packages
-      packages: write #permissions for publishing Docker images to Github Packages
-          
+  test_job:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
     defaults:
       run:
-        working-directory: angular 
+        working-directory: angular
 
     strategy:
       matrix:
         node-version: [16.x]
        #node-version: [16.x, 14.x] #used this line instead of the one above to emulate errors in the test phase AND to test matrix syntax
+    
     steps:
       - uses: actions/checkout@v3
       
@@ -33,18 +31,10 @@ jobs:
       - name: Install dependencies
         #run: npm install
         run: npm ci  		#"ci" is (theoretically?) faster than "install"
-      
-      - name: Buld phase
-        run: npm run build
-      
-      - name: print working dir
-        run: |
-          echo $PWD
-      - run: "ls $PWD"
-      - run: "ls /home/runner/work/angular-react-starter/angular-react-starter/angular/dist/angular-starter"
-      - run: "ls ${{ github.workspace }}"
-      - run: "echo $HOME"
 
+      - name: Linting
+        run: npm run lint
+     
       - name: Test phase
         id: test_phase
         run: npm run test -- --watch=false --browsers=ChromeHeadless
@@ -53,31 +43,6 @@ jobs:
         if: ${{ failure() && steps.test_phase.conclusion == 'failure' }}
         run: exit 1
 
-      - name: Linting
-        run: npm run lint #not in the task, but still running it... just because I can
-      
-      #---Build Docker image, Login & Publish to Docker Packages---
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ghcr.io/${{ github.repository }}
-            
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: ./angular
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      
       #- name: Job's running time !!!!!this approach DOESN'T WORK!!!! because .run_duration_ms parameter is awailable only after this workflow completion and accessible only from other actions, which isn't possible according to this test task conditions (I can't create additional yaml files)
       #  id: execution_time
       #  run: |
@@ -86,37 +51,133 @@ jobs:
       #      -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
       #      https://api.github.com/repos/${{ github.actor }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/timing
 
-      
-  stats_job:
-    runs-on: ubuntu-latest
-    needs: main_job
+
+  build_job:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    needs: test_job
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    permissions:      
+      contents: read  #permissions for publishing Docker images to Github Packages
+      packages: write #permissions for publishing Docker images to Github Packages
+    
+    defaults:
+      run:
+        working-directory: angular
+    
     steps:
-      - name:  Extract job starting & ending time
+      - uses: actions/checkout@v3
+      
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Buld phase
+        run: npm run build
+
+      #---Build Docker image, Login & Publish to Docker Packages---
+      - name: Log in to the Container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
+
+      - name: build Docker image on push event
+        if: github.event_name == 'push'
+        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
+
+      - name: build Docker image on PR event
+        if: github.event_name == 'pull_request'
+        run: |
+          PR_SHA7=${{github.event.pull_request.head.sha}}
+          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} -t $REGISTRY/$IMAGE_NAME:latest .
+
+      - name: push Docker image on push event
+        if: github.event_name == 'push'
+        run: docker push $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} && docker push $REGISTRY/$IMAGE_NAME:latest
+
+      - name: push Docker image on PR event
+        if: github.event_name == 'pull_request'
+        run: |
+          PR_SHA7=${{github.event.pull_request.head.sha}}
+          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} && docker push $REGISTRY/$IMAGE_NAME:latest
+
+      #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
+      #- name: Log in to the Container registry
+      #  uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      #  with:
+      #    registry: $REGISTRY
+      #    username: ${{ github.actor }} #${{ github.repository_owner }}
+      #    password: ${{ secrets.GITHUB_TOKEN }}
+      
+      #- name: Extract metadata (tags, labels) for Docker
+      #  id: meta
+      #  uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      #  with:
+      #    images: $REGISTRY/$IMAGE_NAME
+            
+      #- name: Build and push Docker image
+      #  uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      #  with:
+      #    context: ./angular
+      #    push: true
+      #    tags: ${{ steps.meta.outputs.tags }}
+      #    labels: ${{ steps.meta.outputs.labels }}
+  
+  stats_job:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    needs: [build_job, test_job]
+    steps:
+      - name:  Extract TEST and BUILD job starting & ending time
         id: execution_timestamps
         run: |
-          echo "::set-output name=starttime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
-      
+          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
+          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].started_at')" && echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].completed_at')"
+
       - name: calculate time
         id: calculate_time
         run: |
-          started_at=${{steps.execution_timestamps.outputs.starttime}}
-          completed_at=${{steps.execution_timestamps.outputs.endtime}}
+          started_at_test=${{steps.execution_timestamps.outputs.starttime_test}}
+          completed_at_test=${{steps.execution_timestamps.outputs.endtime_test}}
+          started_at_build=${{steps.execution_timestamps.outputs.starttime_build}}
+          completed_at_build=${{steps.execution_timestamps.outputs.endtime_build}}
 
-          START_TIME=$(date -d "$started_at" +%s)
-          END_TIME=$(date -d "$completed_at" +%s)
+          START_TIME_TEST=$(date -d "$started_at_test" +%s)
+          END_TIME_TEST=$(date -d "$completed_at_test" +%s)
+          START_TIME_BUILD=$(date -d "$started_at_build" +%s)
+          END_TIME_BUILD=$(date -d "$completed_at_build" +%s)
 
-          ELAPSE=$(( $END_TIME - $START_TIME ))
+          ELAPSE_TEST=$(( $END_TIME_TEST - $START_TIME_TEST ))
+          ELAPSE_BUILD=$(( $END_TIME_BUILD - $START_TIME_BUILD ))
+          ELAPSE=$(( $ELAPSE_TEST + $ELAPSE_BUILD ))
           echo $ELAPSE
           echo "$(($ELAPSE/60/60))h $(($ELAPSE/60%60))m $(($ELAPSE%60))s"
           echo "::set-output name=elpsd::$ELAPSE"
           echo "::set-output name=el_hours::$(($ELAPSE/60/60))"
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
+      
+      - name: get email for Committer on PR or pusher on PUSH
+        id: email
+        run: |
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
+          else
+            echo "::set-output name=user_email::${{ github.event.pusher.email }}"
+          fi
 
       - name: Get job conclusion (success or failure)
         id: job_conclusion
         run: |
-          echo "::set-output name=main_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          echo "::set-output name=test_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          echo "::set-output name=build_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
 
       #---Email notifications v2 with elapsed time---
       - name: Send email notifications for this job v2
@@ -124,22 +185,22 @@ jobs:
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:
           # SMTP server address
-          server_address: ${{secrets.MAIL_SERVER}}
+          server_address: ${{ secrets.MAIL_SERVER }}
           # SMTP server port
           server_port: 465 #587
           # Authenticate as this user to SMTP server
-          username: ${{secrets.MAIL_USERNAME}}
+          username: ${{ secrets.MAIL_USERNAME }}
           # Authenticate with this password to SMTP server
-          password: ${{secrets.MAIL_PASSWORD}}
+          password: ${{ secrets.MAIL_PASSWORD }}
           # Subject of mail message
           subject: Github Actions job result
           # Recipients mail addresses (separated with comma)
-          to: ${{github.event.pusher.email}}
+          to: ${{ steps.email.outputs.user_email }} #${{ github.event.pusher.email }}
           # Full name of mail sender (might be with an email address specified in <>)
           from: Github CI v2
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{github.repository}} has completed. Result status ${{steps.job_conclusion.outputs.main_job_conclusion}}. Time ${{steps.calculate_time.outputs.el_hours}}h ${{steps.calculate_time.outputs.el_minutes}}m ${{steps.calculate_time.outputs.el_seconds}}s (${{steps.calculate_time.outputs.elpsd}} sec)
+          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_job_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_job_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,10 +112,12 @@ jobs:
       - name: get job result
         id: job_conclusion
         run: |
-          for i in 0 1; do
-            echo "::set-output name=job_$i_conclusion::$(curl -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            | jq '.jobs[$i].conclusion')"
+          for i in {0..1}
+          do
+          echo "i: $i"
+          echo "::set-output name=job_$i_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[$i].conclusion')"
+          echo ${{ job_$i_conclusion }}
+          echo ${{ job_0_conclusion }}
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,16 +109,13 @@ jobs:
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
 
-      - name: get job result #echo ${{ job_$i_conclusion }} echo ${{ job_0_conclusion }} echo "i: $i"
+      - name: get job result
         id: job_conclusion
         run: |
           for i in {0..1}
           do
           jobi=job_${i}_conclusion
-          echo "1--$jobi"
-          echo "2--${jobi}"
-          echo "3--${!jobi}"
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[${i}].conclusion')"
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg i "$i" '.jobs[$i].conclusion')"
           done
 
       - id: calculate_duration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,12 @@ name: myCI
 on:
   #workflow_dispatch: #manual start from Github UI or API
   push:
-    branches: [master, dev]
+    branches: dev
   pull_request:
-    branches: [master, dev]
+    branches: dev
 
 jobs:
-  test_job:
+  test:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     defaults:
@@ -23,39 +23,30 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       
-      - name: Install dependencies
-        #run: npm install
-        run: npm ci  		#"ci" is (theoretically?) faster than "install"
+      - name: install
+        run: npm ci
 
-      - name: Linting
+      - name: lint
         run: npm run lint
      
-      - name: Test phase
+      - name: run
         id: test_phase
         run: npm run test -- --watch=false --browsers=ChromeHeadless
 
-      - name: Check if tests were successful and exit on failure
+      - name: check #Check if tests were successful and exit on failure
         if: ${{ failure() && steps.test_phase.conclusion == 'failure' }}
         run: exit 1
 
-      #- name: Job's running time !!!!!this approach DOESN'T WORK!!!! because .run_duration_ms parameter is awailable only after this workflow completion and accessible only from other actions, which isn't possible according to this test task conditions (I can't create additional yaml files)
-      #  id: execution_time
-      #  run: |
-      #    curl \
-      #      -H "Accept: application/vnd.github+json" \ 
-      #      -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-      #      https://api.github.com/repos/${{ github.actor }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/timing
-
-
-  build_job:
+    
+  build:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    needs: test_job
+    needs: test
 
     env:
       REGISTRY: ghcr.io
@@ -72,70 +63,36 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - name: Use Node.js
+      - name: use node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
       
-      - name: Install dependencies
+      - name: install
         run: npm ci
 
-      - name: Buld phase
+      - name: buld
         run: npm run build
 
       #---Build Docker image, Login & Publish to Docker Packages---
-      - name: Log in to the Container registry
+      - name: login #log in to the container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
-      - name: build Docker image on push event
-        if: github.event_name == 'push'
-        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
+      - name: build Docker image on push event ###########
+        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA: -7:0} -t $REGISTRY/$IMAGE_NAME:latest .
 
-      - name: build Docker image on PR event
-        if: github.event_name == 'pull_request'
-        run: |
-          PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} -t $REGISTRY/$IMAGE_NAME:latest .
-
-      - name: push Docker image on push event
+      - name: push Docker image on push event ########
         if: github.event_name == 'push'
         run: docker push $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} && docker push $REGISTRY/$IMAGE_NAME:latest
 
-      - name: push Docker image on PR event
-        if: github.event_name == 'pull_request'
-        run: |
-          PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} && docker push $REGISTRY/$IMAGE_NAME:latest
-
-      #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
-      #- name: Log in to the Container registry
-      #  uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-      #  with:
-      #    registry: $REGISTRY
-      #    username: ${{ github.actor }} #${{ github.repository_owner }}
-      #    password: ${{ secrets.GITHUB_TOKEN }}
-      
-      #- name: Extract metadata (tags, labels) for Docker
-      #  id: meta
-      #  uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-      #  with:
-      #    images: $REGISTRY/$IMAGE_NAME
-            
-      #- name: Build and push Docker image
-      #  uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-      #  with:
-      #    context: ./angular
-      #    push: true
-      #    tags: ${{ steps.meta.outputs.tags }}
-      #    labels: ${{ steps.meta.outputs.labels }}
   
-  stats_job:
+  stats:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     if: ${{ always() }}
-    needs: [build_job, test_job]
+    needs: [build, test]
     steps:
-      - name:  Extract TEST and BUILD job starting & ending time
+      - name:  Extract TEST and BUILD job starting & ending time #####
         id: execution_timestamps
         run: |
           echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
@@ -164,7 +121,7 @@ jobs:
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
       
-      - name: get email for Committer on PR or pusher on PUSH
+      - name: get email for Committer on PR or pusher on PUSH ########
         id: email
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
@@ -173,21 +130,21 @@ jobs:
             echo "::set-output name=user_email::${{ github.event.pusher.email }}"
           fi
 
-      - name: Get job conclusion (success or failure)
+      - name: Get job conclusion (success or failure) ########
         id: job_conclusion
         run: |
-          echo "::set-output name=test_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
-          echo "::set-output name=build_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
+          echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
+          echo "::set-output name=build_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
 
-      #---Email notifications v2 with elapsed time---
-      - name: Send email notifications for this job v2
+      #---Email notifications with elapsed time---
+      - name: Send email notifications for this job
         if: ${{ always() }} #run this step even if previous steps failed
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:
           # SMTP server address
           server_address: ${{ secrets.MAIL_SERVER }}
           # SMTP server port
-          server_port: 465 #587
+          server_port: 465
           # Authenticate as this user to SMTP server
           username: ${{ secrets.MAIL_USERNAME }}
           # Authenticate with this password to SMTP server
@@ -197,10 +154,10 @@ jobs:
           # Recipients mail addresses (separated with comma)
           to: ${{ steps.email.outputs.user_email }} #${{ github.event.pusher.email }}
           # Full name of mail sender (might be with an email address specified in <>)
-          from: Github CI v2
+          from: Github CI
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_job_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_job_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
+          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: install
         run: npm ci
 
-      - name: buld
+      - name: build
         run: npm run build
 
       #---Build Docker image, Login & Publish to remote registry---
@@ -116,10 +116,11 @@ jobs:
           do
           jobi=job_${i}_conclusion
           temp=$i
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg i "$temp" '.jobs[$i].conclusion')"
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --arg ii "$temp" '.jobs[$ii].conclusion')"
           done
 
-      - id: calculate_duration
+      - name: calculate duration
+        id: calculate_duration
         run: |
           printf -v now '%(%s)T'
           ELPSD=$(($now - ${{needs.test.outputs.start_time}}))

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,8 @@ name: myCI
 
 on:
   #workflow_dispatch: #manual start from Github UI or API
-  push:
-    branches: [master, dev]
+  #push:
+    #branches: [master, dev]
   pull_request:
     branches: [master, dev]
 
@@ -87,10 +87,6 @@ jobs:
       - name: Log in to the Container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
-      - name: get PR sha1
-        if: github.event_name == 'pull_request'
-        run: PR_SHA7=${{github.event.pull_request.head.sha}}
-      
       - name: build Docker image on push event
         if: github.event_name == 'push'
         run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
@@ -168,6 +164,16 @@ jobs:
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
 
+      - name: get email
+        id: email
+        run: |
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            git checkout remotes/origin/${{ github.head_ref }}
+            echo "::set-output name=email_address::$(git log -n 1 --pretty=format:%ae)"
+          else
+            echo "::set-output name=email_address::$(${{ github.event.pusher.email }})"
+          fi
+
       - name: Get job conclusion (success or failure)
         id: job_conclusion
         run: |
@@ -190,7 +196,7 @@ jobs:
           # Subject of mail message
           subject: Github Actions job result
           # Recipients mail addresses (separated with comma)
-          to: ${{ github.event.pusher.email }}
+          to: ${{steps.email.outputs.email_address}} #${{ github.event.pusher.email }}
           # Full name of mail sender (might be with an email address specified in <>)
           from: Github CI v2
           # Whether this connection use TLS (default is true if server_port is 465)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,23 +3,25 @@ name: myCI
 on:
   #workflow_dispatch: #manual start from Github UI or API
   push:
-    branches: [master, dev]
-  pull_request:
-    branches: [master, dev]
+    branches: master
+  #pull_request:
+    #branches: master
 
 jobs:
-  test_job:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
+  main_job:
+    runs-on: ubuntu-latest
+    permissions:      
+      contents: read  #permissions for publishing Docker images to Github Packages
+      packages: write #permissions for publishing Docker images to Github Packages
+          
     defaults:
       run:
-        working-directory: angular
+        working-directory: angular 
 
     strategy:
       matrix:
         node-version: [16.x]
        #node-version: [16.x, 14.x] #used this line instead of the one above to emulate errors in the test phase AND to test matrix syntax
-    
     steps:
       - uses: actions/checkout@v3
       
@@ -31,10 +33,18 @@ jobs:
       - name: Install dependencies
         #run: npm install
         run: npm ci  		#"ci" is (theoretically?) faster than "install"
+      
+      - name: Buld phase
+        run: npm run build
+      
+      - name: print working dir
+        run: |
+          echo $PWD
+      - run: "ls $PWD"
+      - run: "ls /home/runner/work/angular-react-starter/angular-react-starter/angular/dist/angular-starter"
+      - run: "ls ${{ github.workspace }}"
+      - run: "echo $HOME"
 
-      - name: Linting
-        run: npm run lint
-     
       - name: Test phase
         id: test_phase
         run: npm run test -- --watch=false --browsers=ChromeHeadless
@@ -43,6 +53,31 @@ jobs:
         if: ${{ failure() && steps.test_phase.conclusion == 'failure' }}
         run: exit 1
 
+      - name: Linting
+        run: npm run lint #not in the task, but still running it... just because I can
+      
+      #---Build Docker image, Login & Publish to Docker Packages---
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ghcr.io/${{ github.repository }}
+            
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./angular
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
       #- name: Job's running time !!!!!this approach DOESN'T WORK!!!! because .run_duration_ms parameter is awailable only after this workflow completion and accessible only from other actions, which isn't possible according to this test task conditions (I can't create additional yaml files)
       #  id: execution_time
       #  run: |
@@ -51,133 +86,37 @@ jobs:
       #      -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
       #      https://api.github.com/repos/${{ github.actor }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/timing
 
-
-  build_job:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    needs: test_job
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-
-    permissions:      
-      contents: read  #permissions for publishing Docker images to Github Packages
-      packages: write #permissions for publishing Docker images to Github Packages
-    
-    defaults:
-      run:
-        working-directory: angular
-    
-    steps:
-      - uses: actions/checkout@v3
       
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Buld phase
-        run: npm run build
-
-      #---Build Docker image, Login & Publish to Docker Packages---
-      - name: Log in to the Container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
-
-      - name: build Docker image on push event
-        if: github.event_name == 'push'
-        run: docker build -t $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} -t $REGISTRY/$IMAGE_NAME:latest .
-
-      - name: build Docker image on PR event
-        if: github.event_name == 'pull_request'
-        run: |
-          PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker build -t $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} -t $REGISTRY/$IMAGE_NAME:latest .
-
-      - name: push Docker image on push event
-        if: github.event_name == 'push'
-        run: docker push $REGISTRY/$IMAGE_NAME:${GITHUB_SHA::7} && docker push $REGISTRY/$IMAGE_NAME:latest
-
-      - name: push Docker image on PR event
-        if: github.event_name == 'pull_request'
-        run: |
-          PR_SHA7=${{github.event.pull_request.head.sha}}
-          docker push $REGISTRY/$IMAGE_NAME:${PR_SHA7::7} && docker push $REGISTRY/$IMAGE_NAME:latest
-
-      #---Build Docker image, Login & Publish to Docker Packages - WITH 3RD PARTY ACTIONS---
-      #- name: Log in to the Container registry
-      #  uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-      #  with:
-      #    registry: $REGISTRY
-      #    username: ${{ github.actor }} #${{ github.repository_owner }}
-      #    password: ${{ secrets.GITHUB_TOKEN }}
-      
-      #- name: Extract metadata (tags, labels) for Docker
-      #  id: meta
-      #  uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-      #  with:
-      #    images: $REGISTRY/$IMAGE_NAME
-            
-      #- name: Build and push Docker image
-      #  uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-      #  with:
-      #    context: ./angular
-      #    push: true
-      #    tags: ${{ steps.meta.outputs.tags }}
-      #    labels: ${{ steps.meta.outputs.labels }}
-  
   stats_job:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    if: ${{ always() }}
-    needs: [build_job, test_job]
+    runs-on: ubuntu-latest
+    needs: main_job
     steps:
-      - name:  Extract TEST and BUILD job starting & ending time
+      - name:  Extract job starting & ending time
         id: execution_timestamps
         run: |
-          echo "::set-output name=starttime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime_test::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
-          echo "::set-output name=starttime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].started_at')" && echo "::set-output name=endtime_build::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].completed_at')"
-
+          echo "::set-output name=starttime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].started_at')" && echo "::set-output name=endtime::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].completed_at')"
+      
       - name: calculate time
         id: calculate_time
         run: |
-          started_at_test=${{steps.execution_timestamps.outputs.starttime_test}}
-          completed_at_test=${{steps.execution_timestamps.outputs.endtime_test}}
-          started_at_build=${{steps.execution_timestamps.outputs.starttime_build}}
-          completed_at_build=${{steps.execution_timestamps.outputs.endtime_build}}
+          started_at=${{steps.execution_timestamps.outputs.starttime}}
+          completed_at=${{steps.execution_timestamps.outputs.endtime}}
 
-          START_TIME_TEST=$(date -d "$started_at_test" +%s)
-          END_TIME_TEST=$(date -d "$completed_at_test" +%s)
-          START_TIME_BUILD=$(date -d "$started_at_build" +%s)
-          END_TIME_BUILD=$(date -d "$completed_at_build" +%s)
+          START_TIME=$(date -d "$started_at" +%s)
+          END_TIME=$(date -d "$completed_at" +%s)
 
-          ELAPSE_TEST=$(( $END_TIME_TEST - $START_TIME_TEST ))
-          ELAPSE_BUILD=$(( $END_TIME_BUILD - $START_TIME_BUILD ))
-          ELAPSE=$(( $ELAPSE_TEST + $ELAPSE_BUILD ))
+          ELAPSE=$(( $END_TIME - $START_TIME ))
           echo $ELAPSE
           echo "$(($ELAPSE/60/60))h $(($ELAPSE/60%60))m $(($ELAPSE%60))s"
           echo "::set-output name=elpsd::$ELAPSE"
           echo "::set-output name=el_hours::$(($ELAPSE/60/60))"
           echo "::set-output name=el_minutes::$(($ELAPSE/60%60))"
           echo "::set-output name=el_seconds::$(($ELAPSE%60))"
-      
-      - name: get email for Committer on PR or pusher on PUSH
-        id: email
-        run: |
-          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=user_email::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs | jq '.workflow_runs[0].head_commit.committer.email')"
-          else
-            echo "::set-output name=user_email::${{ github.event.pusher.email }}"
-          fi
 
       - name: Get job conclusion (success or failure)
         id: job_conclusion
         run: |
-          echo "::set-output name=test_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
-          echo "::set-output name=build_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[1].conclusion')"
+          echo "::set-output name=main_job_conclusion::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.jobs[0].conclusion')"
 
       #---Email notifications v2 with elapsed time---
       - name: Send email notifications for this job v2
@@ -185,22 +124,22 @@ jobs:
         uses: dawidd6/action-send-mail@6d23605227c578d570e5594931720f85a1af55a2
         with:
           # SMTP server address
-          server_address: ${{ secrets.MAIL_SERVER }}
+          server_address: ${{secrets.MAIL_SERVER}}
           # SMTP server port
           server_port: 465 #587
           # Authenticate as this user to SMTP server
-          username: ${{ secrets.MAIL_USERNAME }}
+          username: ${{secrets.MAIL_USERNAME}}
           # Authenticate with this password to SMTP server
-          password: ${{ secrets.MAIL_PASSWORD }}
+          password: ${{secrets.MAIL_PASSWORD}}
           # Subject of mail message
           subject: Github Actions job result
           # Recipients mail addresses (separated with comma)
-          to: ${{ steps.email.outputs.user_email }} #${{ github.event.pusher.email }}
+          to: ${{github.event.pusher.email}}
           # Full name of mail sender (might be with an email address specified in <>)
           from: Github CI v2
           # Whether this connection use TLS (default is true if server_port is 465)
           secure: true
           # Body of mail message (might be a filename prefixed with file:// to read from)
-          body: Build job for ${{ github.repository }} has completed. Result status for TESTS-${{ steps.job_conclusion.outputs.test_job_conclusion }}, for BUILD JOB-${{ steps.job_conclusion.outputs.build_job_conclusion }} . Time ${{ steps.calculate_time.outputs.el_hours }}h ${{ steps.calculate_time.outputs.el_minutes }}m ${{ steps.calculate_time.outputs.el_seconds }}s (${{ steps.calculate_time.outputs.elpsd }} sec)
+          body: Build job for ${{github.repository}} has completed. Result status ${{steps.job_conclusion.outputs.main_job_conclusion}}. Time ${{steps.calculate_time.outputs.el_hours}}h ${{steps.calculate_time.outputs.el_minutes}}m ${{steps.calculate_time.outputs.el_seconds}}s (${{steps.calculate_time.outputs.elpsd}} sec)
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ name: myCI
 on:
   #workflow_dispatch: #manual start from Github UI or API
   push:
-    branches: master
+    branches: dev
   pull_request:
-    branches: master
+    branches: dev
 
 jobs:
   test:
@@ -98,6 +98,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ always() }}
     needs: [build, test]
+    
+    strategy:
+      matrix:
+        job-index: [0, 1]
+
     steps:
       - name: get email
         id: email
@@ -111,12 +116,9 @@ jobs:
       - name: get job result
         id: job_conclusion
         run: |
-          echo "::set-output name=test_conclusion::$(curl -H "Accept: application/vnd.github+json" \
+          echo "::set-output name=job_${{ matrix.job-index }}_conclusion::$(curl -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[0].conclusion')"
-          echo "::set-output name=build_conclusion::$(curl -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[1].conclusion')"
+          | jq '.jobs[${{ matrix.job-index }}].conclusion')"
 
       - id: calculate_duration
         run: |
@@ -148,8 +150,8 @@ jobs:
           # Body of mail message (might be a filename prefixed with file:// to read from)
           body: |
             Build job for ${{ github.repository }} has completed.
-            Result status for TESTS-${{ steps.job_conclusion.outputs.test_conclusion }},
-            for BUILD JOB-${{ steps.job_conclusion.outputs.build_conclusion }}.
+            Result status for TESTS-${{ steps.job_conclusion.outputs.job_0_conclusion }},
+            for BUILD JOB-${{ steps.job_conclusion.outputs.job_1_conclusion }}.
             Workflow execution time ${{ steps.calculate_duration.outputs.elapsed }} sec.
           # Allow unsigned/invalid certificates
           ignore_cert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,9 +116,12 @@ jobs:
       - name: get job result
         id: job_conclusion
         run: |
-          echo "::set-output name=job_${{ matrix.job-index }}_conclusion::$(curl -H "Accept: application/vnd.github+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          | jq '.jobs[${{ matrix.job-index }}].conclusion')"
+          for i in 0 1
+          do
+            echo "::set-output name=job_$i_conclusion::$(curl -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            | jq '.jobs[$i].conclusion')"
+          done
 
       - id: calculate_duration
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,8 +115,9 @@ jobs:
           for i in {0..1}
           do
           jobi=job_${i}_conclusion
-          temp=$i
-          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq --argjson ii "$temp" '.jobs[$ii].conclusion')"
+          echo "::set-output name=${jobi}::$(curl -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          | jq --argjson i "$i" '.jobs[$i].conclusion')"
           done
 
       - name: calculate duration


### PR DESCRIPTION
- One main job is divided into two jobs: test and build
- Workflow time is calculated for both jobs
- SHA1 is used to tag Docker images
- Applies some of the best practices for GitHub Actions
- Rids of unnecessary 3rd party Actions for better security
- Notifications now work for PR (as well as for PUSH) and sent to committer email)